### PR TITLE
Exclude everything under src/ezplublish_legacy

### DIFF
--- a/config/app/services.yaml
+++ b/config/app/services.yaml
@@ -16,6 +16,7 @@ services:
     App\:
         resource: '../../src/'
         exclude:
+            - '../../src/ezpublish_legacy/'
             - '../../src/DependencyInjection/'
             - '../../src/Entity/'
             - '../../src/Kernel.php'


### PR DESCRIPTION
I believe we do not want any symfony services under that directory. If that's not true - feel free to just reject this.