### PR TITLE
NGSTACK-901 re-enable imagemagick in ngadminui

### DIFF
--- a/.env
+++ b/.env
@@ -110,3 +110,5 @@ SENTRY_DSN=
 # postgresql+advisory://db_user:db_password@localhost/db_name
 LOCK_DSN=flock
 ###< symfony/lock ###
+
+IMAGEMAGICK_PATH="/usr/bin"

--- a/.env.local.dist
+++ b/.env.local.dist
@@ -14,3 +14,4 @@
 SERVER_ENVIRONMENT=local
 DATABASE_URL="mysql://admin:admin@127.0.0.1:3306/mediasite?serverVersion=8&charset=utf8mb4"
 MAILER_DSN="smtp://0.0.0.0:1025"
+IMAGEMAGICK_PATH="/usr/bin"

--- a/config/app/app_legacy.yaml
+++ b/config/app/app_legacy.yaml
@@ -1,0 +1,3 @@
+parameters:
+    ibexa.image.imagemagick.enabled: true
+    ibexa.image.imagemagick.executable_path: '%env(IMAGEMAGICK_PATH)%'

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -51,6 +51,7 @@ final class Kernel extends BaseKernel
         $container->import($configDir . '/app/services.yaml');
         $container->import($configDir . '/app/{services}/**/*.yaml');
         $container->import($configDir . '/app/app.yaml');
+        $container->import($configDir . '/app/app_legacy.yaml');
 
         $serverEnvironment = $_SERVER['SERVER_ENVIRONMENT'];
         if (preg_match('/^\w+$/', $serverEnvironment) !== 1) {


### PR DESCRIPTION
Due to the configuration changes between versions, we need to add some additional parameters in order to enable ImageMagick in the legacy kernel, and make the executable path configurable